### PR TITLE
Change CoreText values in AppleTV.h to const

### DIFF
--- a/Backrow/AppleTV-Structs.h
+++ b/Backrow/AppleTV-Structs.h
@@ -59,9 +59,9 @@ typedef struct __CFSocket *CFSocketRef;
 
 
 
-typedef struct __SCPreferences *SCPreferencesRef;
+typedef const struct __SCPreferences *SCPreferencesRef;
 
-typedef struct __SCNetworkService *SCNetworkServiceRef;
+typedef const struct __SCNetworkService *SCNetworkServiceRef;
 
 
 
@@ -161,13 +161,13 @@ typedef struct BRFocusEdge {
 	CGPoint _field2;
 } BRFocusEdge;
 
-typedef struct __CTFont *CTFontRef;
+typedef const struct __CTFont *CTFontRef;
 
-typedef struct __SCDynamicStore *SCDynamicStoreRef;
+typedef const struct __SCDynamicStore *SCDynamicStoreRef;
 
-typedef struct __CTLine *CTLineRef;
+typedef const struct __CTLine *CTLineRef;
 
-typedef struct __CTTypesetter *CTTypesetterRef;
+typedef const struct __CTTypesetter *CTTypesetterRef;
 
 typedef struct HttpStreamReader HttpStreamReader;
 


### PR DESCRIPTION
Hello,

I getting SMFramework to work with Plex ATV Plugin, I had some problems with the CoreText definitions being const these days. This patch fixes that problem.
