### PR TITLE
Collisions between Backrow-Structs.h and AppleTV-Structs.h

### DIFF
--- a/Backrow/BackRow-Structs.h
+++ b/Backrow/BackRow-Structs.h
@@ -5,6 +5,7 @@
  * Source: /System/Library/PrivateFrameworks/BackRow.framework/BackRow
  */
 
+#if 0
 typedef struct __ATVMediaItem *ATVMediaItemRef;
 
 typedef struct BRMultiPartImageMap {
@@ -33,3 +34,4 @@ typedef struct __ATVMediaCollection *ATVMediaCollectionRef;
 typedef struct __ATVMediaType *ATVMediaTypeRef;
 
 
+#endif


### PR DESCRIPTION
The two files seems to define the same symbols. I have disabled this in Backrow-Structs.h, but I am not really sure that this is the right way to go. Please advice if this is not good in some way.
